### PR TITLE
Added face cognitive service - Show emotion in result page

### DIFF
--- a/src/Functions/SantaTalk.Functions/SantaTalk.Functions.sln
+++ b/src/Functions/SantaTalk.Functions/SantaTalk.Functions.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SantaTalk.Functions", "SantaTalk.Functions.csproj", "{F98A568D-8F95-48FE-B1DC-7F8EF9F3431F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F98A568D-8F95-48FE-B1DC-7F8EF9F3431F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F98A568D-8F95-48FE-B1DC-7F8EF9F3431F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F98A568D-8F95-48FE-B1DC-7F8EF9F3431F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F98A568D-8F95-48FE-B1DC-7F8EF9F3431F}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/src/SantaTalk.Android/MainActivity.cs
+++ b/src/SantaTalk.Android/MainActivity.cs
@@ -6,6 +6,7 @@ using Android.Runtime;
 using Android.Views;
 using Android.Widget;
 using Android.OS;
+using Plugin.CurrentActivity;
 
 namespace SantaTalk.Droid
 {
@@ -19,6 +20,8 @@ namespace SantaTalk.Droid
 
             base.OnCreate(savedInstanceState);
 
+            CrossCurrentActivity.Current.Init(this, savedInstanceState);
+
             Xamarin.Essentials.Platform.Init(this, savedInstanceState);
             global::Xamarin.Forms.Forms.Init(this, savedInstanceState);
             FFImageLoading.Forms.Platform.CachedImageRenderer.Init(true);
@@ -27,8 +30,10 @@ namespace SantaTalk.Droid
         public override void OnRequestPermissionsResult(int requestCode, string[] permissions, [GeneratedEnum] Android.Content.PM.Permission[] grantResults)
         {
             Xamarin.Essentials.Platform.OnRequestPermissionsResult(requestCode, permissions, grantResults);
+            Plugin.Permissions.PermissionsImplementation.Current.OnRequestPermissionsResult(requestCode, permissions, grantResults);
 
             base.OnRequestPermissionsResult(requestCode, permissions, grantResults);
         }
+
     }
 }

--- a/src/SantaTalk.Android/MainApplication.cs
+++ b/src/SantaTalk.Android/MainApplication.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using Android.App;
+using Android.Runtime;
+using Plugin.CurrentActivity;
+
+#if DEBUG
+[Application(Debuggable = true)]
+#else
+    [Application(Debuggable = false)]
+#endif
+public class MainApplication : Application
+{
+    public MainApplication(IntPtr handle, JniHandleOwnership transer)
+      : base(handle, transer)
+    {
+    }
+
+    public override void OnCreate()
+    {
+        base.OnCreate();
+        CrossCurrentActivity.Current.Init(this);
+    }
+}

--- a/src/SantaTalk.Android/Properties/AndroidManifest.xml
+++ b/src/SantaTalk.Android/Properties/AndroidManifest.xml
@@ -1,6 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.codemilltech.santatalk">
 	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="28" />
-	<application android:label="SantaTalk.Android" android:networkSecurityConfig="@xml/network_security_config"></application>
+	<application android:label="SantaTalk.Android" android:networkSecurityConfig="@xml/network_security_config">
+		<provider android:name="android.support.v4.content.FileProvider" android:authorities="${applicationId}.fileprovider" android:exported="false" android:grantUriPermissions="true">
+			<meta-data android:name="android.support.FILE_PROVIDER_PATHS" android:resource="@xml/file_paths"></meta-data>
+		</provider>
+	</application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 </manifest>

--- a/src/SantaTalk.Android/Properties/AssemblyInfo.cs
+++ b/src/SantaTalk.Android/Properties/AssemblyInfo.cs
@@ -32,3 +32,6 @@ using Android.App;
 // Add some common permissions, these can be removed if not needed
 [assembly: UsesPermission(Android.Manifest.Permission.Internet)]
 [assembly: UsesPermission(Android.Manifest.Permission.WriteExternalStorage)]
+
+[assembly: UsesFeature("android.hardware.camera", Required = true)]
+[assembly: UsesFeature("android.hardware.camera.autofocus", Required = true)]

--- a/src/SantaTalk.Android/Resources/Resource.designer.cs
+++ b/src/SantaTalk.Android/Resources/Resource.designer.cs
@@ -11424,10 +11424,13 @@ namespace SantaTalk.Droid
 		{
 			
 			// aapt resource value: 0x7F100000
-			public const int network_security_config = 2131755008;
+			public const int file_paths = 2131755008;
 			
 			// aapt resource value: 0x7F100001
-			public const int xamarin_essentials_fileprovider_file_paths = 2131755009;
+			public const int network_security_config = 2131755009;
+			
+			// aapt resource value: 0x7F100002
+			public const int xamarin_essentials_fileprovider_file_paths = 2131755010;
 			
 			static Xml()
 			{

--- a/src/SantaTalk.Android/Resources/xml/file_paths.xml
+++ b/src/SantaTalk.Android/Resources/xml/file_paths.xml
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-files-path name="my_images" path="Pictures" />
+    <external-files-path name="my_movies" path="Movies" />
+</paths>

--- a/src/SantaTalk.Android/SantaTalk.Android.csproj
+++ b/src/SantaTalk.Android/SantaTalk.Android.csproj
@@ -69,11 +69,18 @@
     <PackageReference Include="Newtonsoft.Json">
       <Version>12.0.3</Version>
     </PackageReference>
+    <PackageReference Include="Xam.Plugin.Media">
+      <Version>4.0.1.5</Version>
+    </PackageReference>
+    <PackageReference Include="Plugin.CurrentActivity">
+      <Version>2.1.0.4</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />
     <Compile Include="Resources\Resource.designer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="MainApplication.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\AboutResources.txt" />
@@ -122,6 +129,10 @@
       <Generator></Generator>
     </AndroidResource>
     <AndroidResource Include="Resources\drawable-hdpi\star.png">
+      <SubType></SubType>
+      <Generator></Generator>
+    </AndroidResource>
+    <AndroidResource Include="Resources\xml\file_paths.xml">
       <SubType></SubType>
       <Generator></Generator>
     </AndroidResource>

--- a/src/SantaTalk.iOS/Info.plist
+++ b/src/SantaTalk.iOS/Info.plist
@@ -39,6 +39,14 @@
 		<key>NSAllowLocalNetworking</key>
 		<true/>
 	</dict>
+	<key>NSCameraUsageDescription</key>
+<string>This app needs access to the camera to take photos.</string>
+<key>NSPhotoLibraryUsageDescription</key>
+<string>This app needs access to photos.</string>
+<key>NSMicrophoneUsageDescription</key>
+<string>This app needs access to microphone.</string>
+<key>NSPhotoLibraryAddUsageDescription</key>
+<string>This app needs access to the photo gallery.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>futura_book.ttf</string>

--- a/src/SantaTalk.iOS/SantaTalk.iOS.csproj
+++ b/src/SantaTalk.iOS/SantaTalk.iOS.csproj
@@ -139,6 +139,9 @@
     <PackageReference Include="Newtonsoft.Json">
       <Version>12.0.3</Version>
     </PackageReference>
+    <PackageReference Include="Xam.Plugin.Media">
+      <Version>4.0.1.5</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>

--- a/src/SantaTalk/MainPage.xaml
+++ b/src/SantaTalk/MainPage.xaml
@@ -1,49 +1,59 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<ContentPage
-    xmlns="http://xamarin.com/schemas/2014/forms"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"
-    xmlns:controls="clr-namespace:Xamarin.Forms.PancakeView;assembly=Xamarin.Forms.PancakeView"
-    xmlns:viewmodels="clr-namespace:SantaTalk"
-    mc:Ignorable="d"
-    NavigationPage.HasNavigationBar="False"
-    NavigationPage.BackButtonTitle=""
-    ios:Page.UseSafeArea="True"
-    BackgroundColor="{StaticResource dark_gradient}"
-    x:Class="SantaTalk.MainPage">
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage x:Class="SantaTalk.MainPage"
+             xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:controls="clr-namespace:Xamarin.Forms.PancakeView;assembly=Xamarin.Forms.PancakeView"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:viewmodels="clr-namespace:SantaTalk"
+             ios:Page.UseSafeArea="True"
+             BackgroundColor="{StaticResource dark_gradient}"
+             NavigationPage.BackButtonTitle=""
+             NavigationPage.HasNavigationBar="False"
+             mc:Ignorable="d">
 
     <ContentPage.BindingContext>
         <viewmodels:MainPageViewModel />
     </ContentPage.BindingContext>
 
-    <controls:PancakeView BackgroundGradientStartColor="{StaticResource dark_gradient}" 
-                          BackgroundGradientEndColor="{StaticResource light_gradient}">
+    <controls:PancakeView BackgroundGradientEndColor="{StaticResource light_gradient}" BackgroundGradientStartColor="{StaticResource dark_gradient}">
 
         <Grid x:Name="MainGrid">
             <ScrollView VerticalOptions="FillAndExpand">
-                <StackLayout VerticalOptions="FillAndExpand" Padding="24" Spacing="0">
+                <StackLayout Padding="24"
+                             Spacing="0"
+                             VerticalOptions="FillAndExpand">
                     <StackLayout VerticalOptions="CenterAndExpand">
-                        <Label Text="WELCOME TO" FontSize="16" TextColor="{StaticResource highlight_text}"/>
-                        <Label Text="Santa Talk" FontSize="48"/>
-                        <Label Margin="0,24,0,16" FontSize="15" Text="Write Santa a letter, and he'll instantly let you know if you've been naughty or nice!" />
+                        <Label FontSize="16"
+                               Text="WELCOME TO"
+                               TextColor="{StaticResource highlight_text}" />
+                        <Label FontSize="48" Text="Santa Talk" />
+                        <Label Margin="0,24,0,16"
+                               FontSize="15"
+                               Text="Write Santa a letter, and he'll instantly let you know if you've been naughty or nice!" />
                     </StackLayout>
                     <StackLayout Spacing="16" VerticalOptions="CenterAndExpand">
                         <StackLayout Spacing="8">
-                            <Label Text="WHAT'S YOUR NAME?" FontSize="12"/>
+                            <Label FontSize="12" Text="WHAT'S YOUR NAME?" />
                             <Entry Text="{Binding KidsName}" />
                         </StackLayout>
                         <StackLayout Spacing="8">
-                            <Label Text="WRITE YOUR LETTER TO SANTA" FontSize="12"/>
-                            <Editor Text="{Binding LetterText}" TextColor="White"/>
+                            <Label FontSize="12" Text="WRITE YOUR LETTER TO SANTA" />
+                            <Editor Text="{Binding LetterText}" TextColor="White" />
                         </StackLayout>
+                        <Image Source="{Binding Photo}" />
+                        <Button Margin="16"
+                                Command="{Binding TakePictureCommand}"
+                                Text="TAKE PHOTO TO SANTA"
+                                VerticalOptions="EndAndExpand" />
                     </StackLayout>
-                    <Button VerticalOptions="EndAndExpand" Text="SEND TO SANTA" Margin="16" Command="{Binding SendLetterCommand}" />
+                    <Button Margin="16"
+                            Command="{Binding SendLetterCommand}"
+                            Text="SEND TO SANTA"
+                            VerticalOptions="EndAndExpand" />
                 </StackLayout>
             </ScrollView>
         </Grid>
-
     </controls:PancakeView>
-
 </ContentPage>

--- a/src/SantaTalk/Models/Face.cs
+++ b/src/SantaTalk/Models/Face.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+
+namespace SantaTalk.Models
+{
+    public class Face
+    {
+        [JsonProperty("smile")]
+        public double Smile { get; set; }
+
+        [JsonProperty("gender")]
+        public string Gender { get; set; }
+
+        [JsonProperty("age")]
+        public double Age { get; set; }
+
+        [JsonProperty("emotion")]
+        public Dictionary<string, double> Emotions;
+
+        public string CurrentEmotion()
+        {
+            var emotions = Emotions.OrderByDescending(x => x.Value);
+            return emotions.FirstOrDefault().Key;
+        }
+    }
+}

--- a/src/SantaTalk/ResultsPage.xaml
+++ b/src/SantaTalk/ResultsPage.xaml
@@ -60,6 +60,10 @@
 
                             <controls:PancakeView Margin="0,24,0,0" BackgroundColor="{StaticResource white}" CornerRadius="8">
                                 <StackLayout Padding="24" Spacing="8">
+                                    <StackLayout IsVisible="{Binding TheresFoto}">
+                                        <Label Text="Here is Santa! And I really like your photo .. and it shows me that you are: " Style="{StaticResource SantaText}"/>
+                                        <Label Text="{Binding EmotionPhoto}" FontSize="Large" FontAttributes="Bold"  Style="{StaticResource SantaText}"/>
+                                    </StackLayout>
                                     <Label Text="I think it's very nice that you took the time to write me." Style="{StaticResource SantaText}" />
                                     <Label Style="{StaticResource SantaText}">
                                         <Label.FormattedText>

--- a/src/SantaTalk/ResultsPage.xaml.cs
+++ b/src/SantaTalk/ResultsPage.xaml.cs
@@ -19,7 +19,7 @@ namespace SantaTalk
         private List<VisualElement> _stars = new List<VisualElement>();
         private ResultsPageViewModel vm = new ResultsPageViewModel();
 
-        public ResultsPage(string kidsName, string letterText)
+        public ResultsPage(string kidsName, string letterText, string filePath)
         {
             InitializeComponent();
 
@@ -28,6 +28,7 @@ namespace SantaTalk
             vm.KidsName = kidsName;
             vm.LetterText = letterText;
             vm.CurrentState = State.Loading;
+            vm.FilePath = filePath;
 
             _formsWidth = Convert.ToInt32(DeviceDisplay.MainDisplayInfo.Width / DeviceDisplay.MainDisplayInfo.Density);
             _formsHeight = Convert.ToInt32(DeviceDisplay.MainDisplayInfo.Height / DeviceDisplay.MainDisplayInfo.Density);

--- a/src/SantaTalk/SantaTalk.csproj
+++ b/src/SantaTalk/SantaTalk.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Xamarin.Forms.PancakeView" Version="1.3.6" />
     <PackageReference Include="Xamarin.Forms.StateSquid" Version="1.1.3" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Xam.Plugin.Media" Version="4.0.1.5" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Functions\SantaTalk.Models\SantaTalk.Models.csproj" />
@@ -25,5 +26,6 @@
   <ItemGroup>
     <Folder Include="Services\" />
     <Folder Include="ViewModels\" />
+    <Folder Include="Models\" />
   </ItemGroup>
 </Project>

--- a/src/SantaTalk/Services/FaceResponse.cs
+++ b/src/SantaTalk/Services/FaceResponse.cs
@@ -1,0 +1,9 @@
+﻿using SantaTalk.Models;
+
+namespace SantaTalk.Services
+{
+    public class FaceResponse
+    {
+        public Face FaceAttributes { get; set; }
+    }
+}

--- a/src/SantaTalk/Services/PhotoDeliveryService.cs
+++ b/src/SantaTalk/Services/PhotoDeliveryService.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace SantaTalk.Services
+{
+    public class PhotoDeliveryService
+    {
+        const string subscriptionKey = "4c8b5bdac07d45e58a64734a1a10eff6";
+        const string uriBase = "https://brazilsouth.api.cognitive.microsoft.com/face/v1.0/detect";
+
+        public async Task<List<FaceResponse>> MakeAnalysisRequest(string imageFilePath)
+        {
+            var httpClient = new HttpClient();
+
+            httpClient.DefaultRequestHeaders.Add("Ocp-Apim-Subscription-Key", subscriptionKey);
+
+            string requestParameters = "returnFaceId=true&returnFaceLandmarks=false" +
+                "&returnFaceAttributes=age,gender,headPose,smile,facialHair,glasses," +
+                "emotion,hair,makeup,occlusion,accessories,blur,exposure,noise";
+
+            string uri = uriBase + "?" + requestParameters;
+
+            byte[] byteData = GetImageAsByteArray(imageFilePath);
+
+            List<FaceResponse> result;
+
+            using (ByteArrayContent content = new ByteArrayContent(byteData))
+            {
+                content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+
+                var response = await httpClient.PostAsync(uri, content);
+
+                string contentString = await response.Content.ReadAsStringAsync();
+
+                result = JsonConvert.DeserializeObject<List<FaceResponse>>(contentString);
+            }
+
+            return result;
+        }
+
+        private byte[] GetImageAsByteArray(string imageFilePath)
+        {
+            using (FileStream fileStream = new FileStream(imageFilePath, FileMode.Open, FileAccess.Read))
+            {
+                BinaryReader binaryReader = new BinaryReader(fileStream);
+                return binaryReader.ReadBytes((int)fileStream.Length);
+            }
+        }
+    }
+}
+

--- a/src/SantaTalk/ViewModels/MainPageViewModel.cs
+++ b/src/SantaTalk/ViewModels/MainPageViewModel.cs
@@ -1,18 +1,20 @@
 ﻿using System;
 using System.Windows.Input;
 using MvvmHelpers;
+using Plugin.Media;
 using Xamarin.Forms;
 
 namespace SantaTalk
 {
     public class MainPageViewModel : BaseViewModel
     {
-        public MainPageViewModel()
+        public string FilePath { get; set; }
+
+        ImageSource photo;
+        public ImageSource Photo
         {
-            SendLetterCommand = new Command(async () =>
-            {
-                await Application.Current.MainPage.Navigation.PushAsync(new ResultsPage(KidsName, LetterText));
-            });
+            get => photo;
+            set => SetProperty(ref photo, value);
         }
 
         string kidsName;
@@ -29,6 +31,54 @@ namespace SantaTalk
             set => SetProperty(ref letterText, value);
         }
 
+        bool readyToSend;
+        public bool ReadyToSend
+        {
+            get => readyToSend;
+            set => SetProperty(ref readyToSend, value);
+        }
+
         public ICommand SendLetterCommand { get; }
+
+        public ICommand TakePictureCommand { get; }
+
+        public ICommand SendPhotoCommand { get; set; }
+
+        public MainPageViewModel()
+        {
+            SendLetterCommand = new Command(async () =>
+            {
+                await Application.Current.MainPage.Navigation.PushAsync(new ResultsPage(KidsName, LetterText, FilePath));
+            });
+
+            TakePictureCommand = new Command(async () =>
+            {
+                await CrossMedia.Current.Initialize();
+
+                if (!CrossMedia.Current.IsCameraAvailable || !CrossMedia.Current.IsTakePhotoSupported)
+                {
+                    Console.Write(@"No Camera :( No camera available");
+                    return;
+                }
+
+                var file = await CrossMedia.Current.TakePhotoAsync(new Plugin.Media.Abstractions.StoreCameraMediaOptions
+                {
+                    Directory = "Sample",
+                    Name = "test.jpg"
+                });
+
+                if (file == null)
+                    return;
+
+                FilePath = file.Path;
+
+                Photo = ImageSource.FromStream(() =>
+                {
+                    var stream = file.GetStream();
+                    file.Dispose();
+                    return stream;
+                });
+            });
+        }
     }
 }


### PR DESCRIPTION
Hi! 

Added Face API Cognitive Service to identify and show the emotion in photo sent to Santa Claus

In the page to input de latter, I added a new button to user take a self and send it to Santa Claus 
In the result page, Santa says your emotion in the self 

![WhatsApp Image 2020-01-02 at 14 32 19 (2)](https://user-images.githubusercontent.com/880232/71682418-71602400-2d6e-11ea-9bf5-28005257ebac.jpeg)
![WhatsApp Image 2020-01-02 at 14 32 19 (1)](https://user-images.githubusercontent.com/880232/71682429-7624d800-2d6e-11ea-8711-593e2f7fed22.jpeg)
![WhatsApp Image 2020-01-02 at 14 32 19](https://user-images.githubusercontent.com/880232/71682434-791fc880-2d6e-11ea-817b-8b3fc2ba4908.jpeg)

It was easy to create the FACE API service in Azure portal. I've implemented the integration by the service API.
All the work was easy to implement and the documentation is very helpful to active this objective

Everything works fine 